### PR TITLE
[FEAT] Add named song references to charts

### DIFF
--- a/Assets/Scripts/Jukebox/RiqBeatmap.cs
+++ b/Assets/Scripts/Jukebox/RiqBeatmap.cs
@@ -11,11 +11,13 @@ namespace Jukebox
 
         public int Version { get => version; }
         public double Offset { get => offset; }
+        public string SongName { get => songName; }
 
         double offset;
         int version;
+        string songName;
 
-        public RiqBeatmap(int version = 2)
+        public RiqBeatmap(int version = 201)
         {
             this.version = version;
         }
@@ -86,6 +88,17 @@ namespace Jukebox
         public RiqBeatmap WithOffset(double offset)
         {
             this.offset = offset;
+            return this;
+        }
+
+        /// <summary>
+        /// Set the song assigned to this beatmap.
+        /// </summary>
+        /// <param name="songName">Song name (normally provided when importing)</param>
+        /// <returns>This <see cref="RiqBeatmap"/> object</returns>
+        public RiqBeatmap WithSongName(string songName)
+        {
+            this.songName = songName;
             return this;
         }
 

--- a/Assets/Scripts/Jukebox/RiqMetadata.cs
+++ b/Assets/Scripts/Jukebox/RiqMetadata.cs
@@ -55,7 +55,7 @@ namespace Jukebox
             }
         }
 
-        public RiqMetadata(int version = 2, string origin = "Jukebox")
+        public RiqMetadata(int version = 201, string origin = "Jukebox")
         {
             Version = version;
             Origin = origin;

--- a/Assets/Scripts/Jukebox/Serializers/RiqBeatmapConverter.cs
+++ b/Assets/Scripts/Jukebox/Serializers/RiqBeatmapConverter.cs
@@ -17,8 +17,20 @@ namespace Jukebox
             int version = obj["version"].Value<int>();
             double offset = obj["offset"].Value<double>();
 
+            string songName;
+            if (obj.ContainsKey("songname"))
+            {
+                songName = obj["songname"].Value<string>();
+            }
+            else
+            {
+                songName = "song0";
+                if (version == 2) version = 201;
+            }
+
             RiqBeatmap beatmap = new(version);
-            beatmap.WithOffset(offset);
+            beatmap.WithOffset(offset)
+                   .WithSongName(songName);
 
             List<string> datamodels = new();
             JObject datamodelsObj = obj["models"].Value<JObject>();
@@ -58,6 +70,9 @@ namespace Jukebox
 
             writer.WritePropertyName("offset");
             writer.WriteValue(value.Offset);
+
+            writer.WritePropertyName("songname");
+            writer.WriteValue(value.SongName);
 
             List<string> datamodels = new();
             List<string> types = new();

--- a/Assets/Scripts/Jukebox/Serializers/RiqMetadataConverter.cs
+++ b/Assets/Scripts/Jukebox/Serializers/RiqMetadataConverter.cs
@@ -18,6 +18,7 @@ namespace Jukebox
             JObject obj = JObject.Load(reader);
 
             version = obj["version"].Value<int>();
+            if (version == 2) version = 201;
 
             if (obj.ContainsKey("origin"))
                 origin = obj["origin"].Value<string>();

--- a/Assets/Scripts/Jukebox/package.json
+++ b/Assets/Scripts/Jukebox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.rheavenstudio.jukebox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "displayName": "Jukebox",
   "description": "Utility to parse and create RIQ-format rhythm game chart files.",
   "unity": "2020.1",

--- a/Assets/Scripts/TestScene/TestsManager.cs
+++ b/Assets/Scripts/TestScene/TestsManager.cs
@@ -158,60 +158,73 @@ namespace Jukebox.Tests
             // DrawWaveformChunk(currentChunkTime);
         }
 
+        IEnumerator LoadChartAndMusic(int idx)
+        {
+            yield return RiqFileHandler.ReadChartAndAudio(idx);
+
+            beatmap2 = RiqFileHandler.GetLoadedChart();
+            audioSource.clip = RiqFileHandler.GetLoadedSong();
+
+            audioLength = audioSource.clip.length;
+            musicSlider.value = 0;
+            songProgressSeconds.text = $"0.000 / {audioLength:0.000}";
+            currentChunkTime = 0f;
+        }
+
         // private void DrawWaveformChunk(float startTime)
         // {
         //     Vector2 imgSize = waveformImg.GetPixelAdjustedRect().size;
         //     StartCoroutine(PaintWaveformSpectrum(startTime, 1f, Mathf.RoundToInt(imgSize.x), Mathf.RoundToInt(imgSize.y), Color.yellow));
         // }
 
-        // https://answers.unity.com/questions/1603418/how-to-create-waveform-texture-from-audioclip.html
-        // and
-        // https://answers.unity.com/questions/699595/how-to-generate-waveform-from-audioclip.html
-        // with modifications to only render chunks of audio
-        // public IEnumerator PaintWaveformSpectrum(float startTime, float length, int width, int height, Color col) {
-        //     AudioClip audio = RiqFileHandler.StreamedAudioClip;
-        //     if (audio == null) yield break;
+            // https://answers.unity.com/questions/1603418/how-to-create-waveform-texture-from-audioclip.html
+            // and
+            // https://answers.unity.com/questions/699595/how-to-generate-waveform-from-audioclip.html
+            // with modifications to only render chunks of audio
+            // public IEnumerator PaintWaveformSpectrum(float startTime, float length, int width, int height, Color col) {
+            //     AudioClip audio = RiqFileHandler.StreamedAudioClip;
+            //     if (audio == null) yield break;
 
-        //     int sampleRate = audio.frequency;
-        //     int channels = audio.channels;
-        //     int numSamples = Mathf.RoundToInt(length * sampleRate);
+            //     int sampleRate = audio.frequency;
+            //     int channels = audio.channels;
+            //     int numSamples = Mathf.RoundToInt(length * sampleRate);
 
-        //     Texture2D tex = new Texture2D(width, height, TextureFormat.RGBA32, false);
+            //     Texture2D tex = new Texture2D(width, height, TextureFormat.RGBA32, false);
 
-        //     yield return RiqFileHandler.GetSongSamples(Mathf.RoundToInt(startTime * sampleRate), numSamples);
-        //     float[] samples = RiqFileHandler.LastSongChunk;
-        //     if (samples == null) yield break;
+            //     yield return RiqFileHandler.GetSongSamples(Mathf.RoundToInt(startTime * sampleRate), numSamples);
+            //     float[] samples = RiqFileHandler.LastSongChunk;
+            //     if (samples == null) yield break;
 
-        //     float[] waveform = new float[width];
-        //     float packSize = ((float)samples.Length / (float)width);
-        //     int waveIdx = 0;
-        //     for (float i = 0; Mathf.RoundToInt(i) < samples.Length && waveIdx < waveform.Length; i += packSize)
-        //     {
-        //         waveform[waveIdx] = Mathf.Abs(samples[Mathf.RoundToInt(i)]);
-        //         waveIdx++;
-        //     }
-        
-        //     for (int x = 0; x < width; x++) {
-        //         for (int y = 0; y < height; y++) {
-        //             tex.SetPixel(x, y, Color.black);
-        //         }
-        //     }
+            //     float[] waveform = new float[width];
+            //     float packSize = ((float)samples.Length / (float)width);
+            //     int waveIdx = 0;
+            //     for (float i = 0; Mathf.RoundToInt(i) < samples.Length && waveIdx < waveform.Length; i += packSize)
+            //     {
+            //         waveform[waveIdx] = Mathf.Abs(samples[Mathf.RoundToInt(i)]);
+            //         waveIdx++;
+            //     }
 
-        //     waveformImg.texture = tex;
-        //     for (int x = 0; x < waveform.Length; x++) {
-        //         for (int y = 0; y <= waveform[x] * ((float)height * .75f); y++) {
-        //             tex.SetPixel(x, ( height / 2 ) + y, col);
-        //             tex.SetPixel(x, ( height / 2 ) - y, col);
-        //         }
-        //         // tex.Apply();
-        //         // yield return null;
-        //     }
-        //     tex.Apply();
-        // }
+            //     for (int x = 0; x < width; x++) {
+            //         for (int y = 0; y < height; y++) {
+            //             tex.SetPixel(x, y, Color.black);
+            //         }
+            //     }
+
+            //     waveformImg.texture = tex;
+            //     for (int x = 0; x < waveform.Length; x++) {
+            //         for (int y = 0; y <= waveform[x] * ((float)height * .75f); y++) {
+            //             tex.SetPixel(x, ( height / 2 ) + y, col);
+            //             tex.SetPixel(x, ( height / 2 ) - y, col);
+            //         }
+            //         // tex.Apply();
+            //         // yield return null;
+            //     }
+            //     tex.Apply();
+            // }
 
         public void OnImportPressed()
         {
-            var extensions = new [] {
+            var extensions = new[] {
                 new ExtensionFilter("RIQ-compatible", "riq"),
             };
             var paths = StandaloneFileBrowser.OpenFilePanel("Open File", "", extensions, false);
@@ -233,8 +246,7 @@ namespace Jukebox.Tests
                 }
 
                 metadata2 = RiqFileHandler.ReadMetadata();
-                beatmap2 = RiqFileHandler.ReadChart(0);
-                StartCoroutine(LoadMusic2(0));
+                StartCoroutine(LoadChartAndMusic(0));
 
                 statusTxt.text = "Imported RIQ successfully!";
                 return;
@@ -329,7 +341,7 @@ namespace Jukebox.Tests
             try
             {
                 if (paths.Length == 0) return;
-                RiqFileHandler.WriteAudio(0, paths[0]);
+                RiqFileHandler.WriteAudio(beatmap2, paths[0]);
                 StartCoroutine(LoadMusic2(0));
                 return;
             }
@@ -387,6 +399,7 @@ namespace Jukebox.Tests
             try
             {
                 RiqFileHandler.WriteMetadata(metadata2);
+                RiqFileHandler.WriteChart(0, beatmap2);
                 RiqFileHandler.Pack(path);
                 statusTxt.text = "Packed RIQ successfully!";
                 return;

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
+    "com.unity.ai.navigation": "1.1.5",
     "com.unity.feature.2d": "2.0.1",
-    "com.unity.ide.rider": "3.0.31",
+    "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.test-framework": "1.1.33",
-    "com.unity.textmeshpro": "3.0.6",
-    "com.unity.timeline": "1.6.5",
+    "com.unity.textmeshpro": "3.0.7",
+    "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.9.4",
     "jillejr.newtonsoft.json-for-unity.converters": "1.6.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,19 +1,20 @@
 {
   "dependencies": {
     "com.unity.2d.animation": {
-      "version": "7.1.1",
+      "version": "9.1.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "6.0.7",
+        "com.unity.2d.common": "8.0.4",
         "com.unity.2d.sprite": "1.0.0",
+        "com.unity.collections": "1.1.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.uielements": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "1.1.6",
+      "version": "1.1.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -25,22 +26,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.common": {
-      "version": "6.0.7",
+      "version": "8.0.4",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.unity.burst": "1.5.1",
+        "com.unity.burst": "1.7.3",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.mathematics": "1.1.0",
+        "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.uielements": "1.0.0"
       },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.2d.path": {
-      "version": "5.0.2",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.pixel-perfect": {
@@ -51,13 +46,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.psdimporter": {
-      "version": "6.0.9",
+      "version": "8.0.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "6.0.7",
+        "com.unity.2d.common": "8.0.2",
         "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.animation": "7.1.0"
+        "com.unity.2d.animation": "9.1.1"
       },
       "url": "https://packages.unity.com"
     },
@@ -68,12 +63,11 @@
       "dependencies": {}
     },
     "com.unity.2d.spriteshape": {
-      "version": "7.0.7",
+      "version": "9.0.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.path": "5.0.2",
-        "com.unity.2d.common": "6.0.6",
+        "com.unity.2d.common": "8.0.4",
         "com.unity.mathematics": "1.1.0",
         "com.unity.modules.physics2d": "1.0.0"
       },
@@ -83,10 +77,13 @@
       "version": "1.0.0",
       "depth": 1,
       "source": "builtin",
-      "dependencies": {}
+      "dependencies": {
+        "com.unity.modules.tilemap": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0"
+      }
     },
     "com.unity.2d.tilemap.extras": {
-      "version": "2.2.7",
+      "version": "3.1.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -97,13 +94,32 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.ai.navigation": {
+      "version": "1.1.5",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.ai": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
-      "version": "1.8.18",
+      "version": "1.8.19",
       "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
         "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.collections": {
+      "version": "1.2.4",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.6.6",
+        "com.unity.test-framework": "1.1.31"
       },
       "url": "https://packages.unity.com"
     },
@@ -119,18 +135,18 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.2d.animation": "7.1.1",
+        "com.unity.2d.animation": "9.1.3",
         "com.unity.2d.pixel-perfect": "5.0.3",
-        "com.unity.2d.psdimporter": "6.0.9",
+        "com.unity.2d.psdimporter": "8.0.5",
         "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.spriteshape": "7.0.7",
+        "com.unity.2d.spriteshape": "9.0.5",
         "com.unity.2d.tilemap": "1.0.0",
-        "com.unity.2d.tilemap.extras": "2.2.7",
-        "com.unity.2d.aseprite": "1.1.6"
+        "com.unity.2d.tilemap.extras": "3.1.3",
+        "com.unity.2d.aseprite": "1.1.8"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.31",
+      "version": "3.0.34",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -173,7 +189,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "3.0.6",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -182,7 +198,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.timeline": {
-      "version": "1.6.5",
+      "version": "1.7.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -350,17 +366,6 @@
     "com.unity.modules.uielements": {
       "version": "1.0.0",
       "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.modules.ui": "1.0.0",
-        "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.uielementsnative": "1.0.0"
-      }
-    },
-    "com.unity.modules.uielementsnative": {
-      "version": "1.0.0",
-      "depth": 1,
       "source": "builtin",
       "dependencies": {
         "com.unity.modules.ui": "1.0.0",

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.45f1
-m_EditorVersionWithRevision: 2021.3.45f1 (0da89fac8e79)
+m_EditorVersion: 2022.3.58f1
+m_EditorVersionWithRevision: 2022.3.58f1 (ed7f6eacb62e)


### PR DESCRIPTION
Replaces the numerical song index with a named referencing system
Also adds API for reading a chart file in a coroutine, and a utility function that loads both a chart and its respective song file